### PR TITLE
fix: Dashboard 页面顶部工具栏高度布局问题

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -93,7 +93,7 @@ export const Dashboard: React.FC = () => {
   return (
     <div className="min-h-screen">
       {/* 页面头部 - 带极光背景 */}
-      <header className="relative min-h-[5rem] py-4">
+      <header className="relative h-[5.5rem] py-4">
         {/* 极光背景 */}
         <Aurora 
           colorStops={['#a855f7', '#7c3aed', '#6366f1']}


### PR DESCRIPTION
## 修复内容

修复 #12 - Dashboard 页面顶部工具栏高度布局问题

### 问题分析

header 使用 `min-h-[5rem]` + `py-4`（上下各 16px），内部 div 使用 `h-full`。
但 `min-height` 不会给 `h-full`（height: 100%）提供明确高度，导致：

- 「同步状态」按钮和「Offline」状态指示器显示异常
- 布局高度计算不正确

### 修复方案

将 `min-h-[5rem]` 改为固定高度 `h-[5.5rem]`，确保工具栏所有元素正确显示。

### 测试

- ✅ 构建成功
- ✅ 无 TypeScript 错误